### PR TITLE
ci: remove token from checkout action for public submodules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,12 +26,18 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           job_name: script
-      - name: checkout with submodule
+      - name: Checkout repository with submodules
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
-          submodules: true
+          submodules: recursive
+          fetch-depth: 1
           token: ${{ secrets.PERSONAL_ACCESSTOKEN }}
+      - name: Debug path check
+        run: |
+          pwd
+          ls -l
+          ls -l LightGBM
+          ls -l LightGBM/docs
       - name: Setup SSH
         uses: MrSquaare/ssh-setup-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,10 @@ on:
     - cron: "0 0 * * *"
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 jobs:
   script:
     permissions:
@@ -39,7 +39,7 @@ jobs:
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: install
         run: |
-          (cd LightGBM; git fetch origin; git checkout main; git reset --hard origin/main; git branch -a)
+          (cd LightGBM; git fetch origin; git checkout master; git reset --hard origin/master; git branch -a)
           pip3 install -U pip setuptools
           pip3 install -r ./requirements.txt
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
@@ -57,7 +57,7 @@ jobs:
           git config --global user.email $GITHUB_REPOSITORY
           git config --global user.name $GITHUB_REPOSITORY
       - name: commit
-        if: contains(github.event.head_commit.message, '[ci skip]') == false && contains(github.ref, 'main')
+        if: contains(github.event.head_commit.message, '[ci skip]') == false && contains(github.ref, 'master')
         env:
           JOB_ID: ${{ steps.jobs.outputs.job_id }}
           HTML_URL: ${{ steps.jobs.outputs.html_url }}
@@ -67,4 +67,4 @@ jobs:
           $HTML_URL"
           git remote -v
           git remote add github git@github.com:$GITHUB_REPOSITORY.git
-          git push github main
+          git push github master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,70 @@
+name: LightGBM-docs-auto-update
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  script:
+    permissions:
+      pull-requests: write
+      issues: write
+      repository-projects: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Get Job URL
+        uses: Tiryoh/gha-jobid-action@v1
+        id: jobs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          job_name: script
+      - name: checkout with submodule
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: true
+          token: ${{ secrets.PERSONAL_ACCESSTOKEN }}
+      - name: Setup SSH
+        uses: MrSquaare/ssh-setup-action@v3
+        with:
+          host: github.com
+          private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: install
+        run: |
+          (cd LightGBM; git fetch origin; git checkout main; git reset --hard origin/main; git branch -a)
+          pip3 install -U pip setuptools
+          pip3 install -r ./requirements.txt
+          curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+          mv tx /usr/local/bin/tx
+      - name: update
+        env:
+          SPHINXINTL_TRANSIFEX_ORGANIZATION_NAME: tkoyama010
+          SPHINXINTL_TRANSIFEX_USERNAME: api
+          SPHINXINTL_TRANSIFEX_PROJECT_NAME: LightGBM-docs
+          TX_TOKEN: ${{ secrets.TX_TOKEN }}
+        run: |
+          sh ./locale/update.sh
+      - name: git_config
+        run: |
+          git config --global user.email $GITHUB_REPOSITORY
+          git config --global user.name $GITHUB_REPOSITORY
+      - name: commit
+        if: contains(github.event.head_commit.message, '[ci skip]') == false && contains(github.ref, 'main')
+        env:
+          JOB_ID: ${{ steps.jobs.outputs.job_id }}
+          HTML_URL: ${{ steps.jobs.outputs.html_url }}
+        run: |
+          git add .
+          git commit --allow-empty -m "[ci skip] $JOB_ID
+          $HTML_URL"
+          git remote -v
+          git remote add github git@github.com:$GITHUB_REPOSITORY.git
+          git push github main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 1
-          token: ${{ secrets.PERSONAL_ACCESSTOKEN }}
       - name: Debug path check
         run: |
           pwd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,9 @@ jobs:
           SPHINXINTL_TRANSIFEX_PROJECT_NAME: LightGBM-docs
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
+          conda activate docs-env
           source ./locale/update.sh
+          conda deactivate
       - name: git_config
         run: |
           git config --global user.email $GITHUB_REPOSITORY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,9 +63,7 @@ jobs:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
           conda activate docs-env
-          cd locale
-          source update.sh
-          cd ..
+          bash locale/update.sh
           conda deactivate
       - name: git_config
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,13 +49,13 @@ jobs:
           environment-file: env.yml
           activate-environment: docs-env
       - name: update
+        shell: bash -l {0}
         env:
           SPHINXINTL_TRANSIFEX_ORGANIZATION_NAME: tkoyama010
           SPHINXINTL_TRANSIFEX_USERNAME: api
           SPHINXINTL_TRANSIFEX_PROJECT_NAME: LightGBM-docs
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
-          conda init
           conda activate docs-env
           source ./locale/update.sh
           conda deactivate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,11 +37,14 @@ jobs:
         with:
           host: github.com
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-activate-base: false
+          environment-file: env.yml
+          activate-environment: docs-env
       - name: install
         run: |
-          (cd LightGBM; git fetch origin; git checkout master; git reset --hard origin/master; git branch -a)
-          pip3 install -U pip setuptools
-          pip3 install -r ./requirements.txt
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
           mv tx /usr/local/bin/tx
       - name: update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,9 @@ jobs:
           SPHINXINTL_TRANSIFEX_PROJECT_NAME: LightGBM-docs
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
+          conda activate docs-env
           sh ./locale/update.sh
+          conda deactivate
       - name: git_config
         run: |
           git config --global user.email $GITHUB_REPOSITORY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,16 +37,17 @@ jobs:
         with:
           host: github.com
           private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          auto-activate-base: false
-          environment-file: env.yml
-          activate-environment: docs-env
       - name: install
         run: |
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
           mv tx /usr/local/bin/tx
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-activate-base: false
+          auto-update-conda: true
+          environment-file: env.yml
+          activate-environment: docs-env
       - name: update
         env:
           SPHINXINTL_TRANSIFEX_ORGANIZATION_NAME: tkoyama010
@@ -54,9 +55,7 @@ jobs:
           SPHINXINTL_TRANSIFEX_PROJECT_NAME: LightGBM-docs
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
-          conda activate docs-env
-          sh ./locale/update.sh
-          conda deactivate
+          bash ./locale/update.sh
       - name: git_config
         run: |
           git config --global user.email $GITHUB_REPOSITORY

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,9 @@ jobs:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
           conda activate docs-env
-          source ./locale/update.sh
+          cd locale
+          source update.sh
+          cd ..
           conda deactivate
       - name: git_config
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
           SPHINXINTL_TRANSIFEX_PROJECT_NAME: LightGBM-docs
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
+          conda init
           conda activate docs-env
           source ./locale/update.sh
           conda deactivate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           SPHINXINTL_TRANSIFEX_PROJECT_NAME: LightGBM-docs
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: |
-          bash ./locale/update.sh
+          source ./locale/update.sh
       - name: git_config
         run: |
           git config --global user.email $GITHUB_REPOSITORY

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "LightGBM"]
+	path = LightGBM
+	url = https://github.com/microsoft/LightGBM.git

--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,19 @@
+name: docs-env
+channels:
+  - nodefaults
+  - conda-forge
+dependencies:
+  - breathe>=4.35
+  - python=3.12
+  - r-base>=4.3.3
+  - r-data.table=1.16.4
+  - r-jsonlite=1.8.9
+  - r-knitr=1.49
+  - r-markdown=1.13
+  - r-matrix=1.6_5
+  - r-pkgdown=2.1.1
+  - r-roxygen2=7.3.2
+  - scikit-learn>=1.6.1
+  - sphinx-intl[transifex]==2.2.0
+  - sphinx>=8.1.3
+  - sphinx_rtd_theme>=3.0.1

--- a/locale/.tx/config
+++ b/locale/.tx/config
@@ -1,0 +1,3 @@
+[main]
+host = https://www.transifex.com
+type = PO

--- a/locale/update.sh
+++ b/locale/update.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# update transifex pot and local po files
+
+set -ex
+
+# required environment variables
+# SPHINXINTL_TRANSIFEX_ORGANIZATION_NAME=tkoyama010
+# SPHINXINTL_TRANSIFEX_PROJECT_NAME=LightGBM-docs
+# TX_TOKEN=...
+
+# pull po files from transifex
+cd `dirname $0`
+#rm -R pot  # skip this line cause "already unused pot files will not removed" but we must keep these files to avoid commit for only "POT-Creation-Time" line updated. see: https://github.com/sphinx-doc/sphinx/issues/3443
+sphinx-build -T -D plot_gallery=0 -b gettext ../LightGBM/docs pot
+sphinx-intl update-txconfig-resources -p pot -d .
+cat .tx/config
+tx push -s --skip
+rm -R -f ja
+tx pull --silent -f -l ja
+git checkout .tx/config

--- a/locale/update.sh
+++ b/locale/update.sh
@@ -7,11 +7,12 @@ set -ex
 # SPHINXINTL_TRANSIFEX_ORGANIZATION_NAME=tkoyama010
 # SPHINXINTL_TRANSIFEX_PROJECT_NAME=LightGBM-docs
 # TX_TOKEN=...
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd)
 
 # pull po files from transifex
-cd `dirname $0`
+cd "$SCRIPT_DIR"
 #rm -R pot  # skip this line cause "already unused pot files will not removed" but we must keep these files to avoid commit for only "POT-Creation-Time" line updated. see: https://github.com/sphinx-doc/sphinx/issues/3443
-sphinx-build -T -D plot_gallery=0 -b gettext ../LightGBM/docs pot
+sphinx-build -T -D plot_gallery=0 -b gettext "$SCRIPT_DIR/../LightGBM/docs" pot
 sphinx-intl update-txconfig-resources -p pot -d .
 cat .tx/config
 tx push -s --skip

--- a/locale/update.sh
+++ b/locale/update.sh
@@ -3,19 +3,29 @@
 
 set -ex
 
-# required environment variables
 # SPHINXINTL_TRANSIFEX_ORGANIZATION_NAME=tkoyama010
 # SPHINXINTL_TRANSIFEX_PROJECT_NAME=LightGBM-docs
 # TX_TOKEN=...
-SCRIPT_DIR=$(cd $(dirname "$0") && pwd)
 
-# pull po files from transifex
-cd "$SCRIPT_DIR"
-#rm -R pot  # skip this line cause "already unused pot files will not removed" but we must keep these files to avoid commit for only "POT-Creation-Time" line updated. see: https://github.com/sphinx-doc/sphinx/issues/3443
-sphinx-build -T -D plot_gallery=0 -b gettext "$SCRIPT_DIR/../LightGBM/docs" pot
-sphinx-intl update-txconfig-resources -p pot -d .
-cat .tx/config
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+SPHINX_SOURCE_DIR="$SCRIPT_DIR/../LightGBM/docs"
+
+POT_DIR="$SCRIPT_DIR/pot"
+
+echo "Using Sphinx source directory: $SPHINX_SOURCE_DIR"
+ls -l "$SPHINX_SOURCE_DIR"
+
+sphinx-build -T -D plot_gallery=0 -b gettext "$SPHINX_SOURCE_DIR" "$POT_DIR"
+
+sphinx-intl update-txconfig-resources -p "$POT_DIR" -d "$SCRIPT_DIR"
+
+cat "$SCRIPT_DIR/.tx/config"
+
 tx push -s --skip
-rm -R -f ja
+
+rm -R -f "$SCRIPT_DIR/ja"
+
 tx pull --silent -f -l ja
-git checkout .tx/config
+
+git checkout "$SCRIPT_DIR/.tx/config"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-intl[transifex]==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-sphinx-intl[transifex]==2.2.0


### PR DESCRIPTION
The submodules in this repository are all public, so a Personal Access Token is not required for `actions/checkout`. Removing it resolves the Dependabot workflow error: `Input required and not supplied: token`.